### PR TITLE
Optimize vue-masonry-wall

### DIFF
--- a/packages/vue-masonry-wall-core/src/index.ts
+++ b/packages/vue-masonry-wall-core/src/index.ts
@@ -15,6 +15,7 @@ export interface ComponentProps<T> {
   minColumns?: number
   maxColumns?: number
   keyMapper?: KeyMapper<T>
+  incremental?: boolean
 }
 
 export type NonEmptyArray<T> = [T, ...T[]]
@@ -59,6 +60,7 @@ export interface HookProps<T> {
   vue: VueVersion
   wall: VueRef<HTMLDivElement>
   watch: Watch
+  incremental: VueRef<boolean>
 }
 
 export function useMasonryWall<T>({
@@ -79,6 +81,7 @@ export function useMasonryWall<T>({
   wall,
   watch,
   keyMapper,
+  incremental,
 }: HookProps<T>) {
   function countIteratively(
     containerWidth: number,
@@ -197,7 +200,7 @@ export function useMasonryWall<T>({
       keyMapper.value(item, 0, 0, index),
     )
     let reuse = 0
-    if (columns.value.length === columnCount()) {
+    if (columns.value.length === columnCount() && incremental) {
       while (
         reuse < newKeys.length &&
         reuse < previousKeys.length &&

--- a/packages/vue-masonry-wall/README.md
+++ b/packages/vue-masonry-wall/README.md
@@ -73,6 +73,7 @@ Props:
 - `min-columns`: Minimum number of columns. `undefined` implies no constraint. Defaults to `undefined`, but will always be at least `1` in the output.
 - `max-columns`: Maximum number of columns. `undefined` implies no constraint. Defaults to `undefined`. If `min-columns` is greater than `max-columns`, `min-columns` will take precedence.
 - `keyMapper`: Optional mapper function that receives an item, its column index, its row index, and its index w.r.t. the `items` array and returns a unique key. Defaults to `(_item, _column, _row, index) => index`.
+- `incremental`: Optional flag that enables incremental rendering. Note that this requires the `keyMapper` to be agnostic to column index and row index. Defaults to `false`.
 
 ```vue
 <script setup lang="ts">

--- a/packages/vue-masonry-wall/src/masonry-wall.vue
+++ b/packages/vue-masonry-wall/src/masonry-wall.vue
@@ -83,16 +83,20 @@ const { getColumnWidthTarget } = useMasonryWall<T>({
         'flex-direction': 'column',
         'flex-grow': 1,
         gap: `${gap}px`,
-        height: [
-          '-webkit-max-content',
-          '-moz-max-content',
-          'max-content',
-        ] as any,
+        height:
+          column.height === undefined
+            ? ([
+                '-webkit-max-content',
+                '-moz-max-content',
+                'max-content',
+              ] as any)
+            : column.height + 'px',
         'min-width': 0,
+        'overflow-y': 'hidden',
       }"
     >
       <div
-        v-for="(itemIndex, row) in column"
+        v-for="(itemIndex, row) in column.items"
         :key="keyMapper(items[itemIndex]!, columnIndex, row, itemIndex)"
         class="masonry-item"
       >

--- a/packages/vue-masonry-wall/src/masonry-wall.vue
+++ b/packages/vue-masonry-wall/src/masonry-wall.vue
@@ -22,6 +22,7 @@ const props = withDefaults(
     minColumns?: number
     maxColumns?: number
     keyMapper?: KeyMapper<T>
+    incremental?: boolean
   }>(),
   {
     columnWidth: 400,
@@ -33,6 +34,7 @@ const props = withDefaults(
     rtl: false,
     scrollContainer: null,
     ssrColumns: 0,
+    incremental: false,
   },
 )
 

--- a/packages/vue2-masonry-wall/README.md
+++ b/packages/vue2-masonry-wall/README.md
@@ -71,6 +71,7 @@ Props:
 - `min-columns`: Minimum number of columns. `undefined` implies no constraint. Defaults to `undefined`, but will always be at least `1` in the output.
 - `max-columns`: Maximum number of columns. `undefined` implies no constraint. Defaults to `undefined`. If `min-columns` is greater than `max-columns`, `min-columns` will take precedence.
 - `keyMapper`: Optional mapper function that receives an item, its column index, its row index, and its index w.r.t. the `items` array and returns a unique key. Defaults to `(_item, _column, _row, index) => index`.
+- `incremental`: Optional flag that enables incremental rendering. Note that this requires the `keyMapper` to be agnostic to column index and row index. Defaults to `false`.
 
 ```vue
 <script>


### PR DESCRIPTION
# Description

Recently I've tried several masonry plugins for Vue (`vue-masonry`, `vue-next-masonry`, `vue-grid-layout`) until I came across your work. It's amazing and perfectly meets my needs. Thanks a lot!

However, while building an infinite scrolling page using the masonry wall, I noticed a performance degradation, especially when the number of items exceeds ~100. Each load (which fetches around 20 items from the server) takes around 5 seconds to render and freezes the webpage.

Upon reviewing the logic, I found that the current implementation rearranges all items whenever there is a change. Also the current implementation does things like: measure all columns' heights, find the smallest one, insert item to it, `await nextTick` and measure all columns' heights again… This is really inefficient as the number of items goes up.

In this PR, `incremental` option (defaulting to false to avoid breaking changes) is introduced to render items incrementally. Specifically, if the keys of items given by `keyMapper(item, 0, 0, index)` remain unchanged, `redraw` will then arrange only updated parts.

Redraw strategy is updated as well. When redrawing, all columns' heights are fixed first (set explicit height in style and `overflow-y: hidden`), and all items are inserted into the first column. After awaiting for a tick, all items' heights can be retrieved and then the algorithm is performed without interacting with DOM.

In my scenario this significantly improves the performance.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation only

Might be a breaking change but I haven't tested thoroughly.

# Checklist:

- [x] My code follows the style and commit guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
