### PR TITLE
fix(vecti): return zero vector when normalizing zero-length input

### DIFF
--- a/.changeset/fix-normalize-nan-on-zero-length.md
+++ b/.changeset/fix-normalize-nan-on-zero-length.md
@@ -1,0 +1,5 @@
+---
+'vecti': patch
+---
+
+fix nan on zero-length normalize

--- a/packages/vecti/src/index.ts
+++ b/packages/vecti/src/index.ts
@@ -98,11 +98,14 @@ export class Vector {
   }
 
   /**
-   * Normalize the vector using the L2 norm.
+   * Normalize the vector using the L2 norm. Returns the zero vector if the vector has zero length.
    * @returns The normalized vector.
    */
   public normalize(): Vector {
     const length = this.length()
+    if (length === 0) {
+      return new Vector(0, 0)
+    }
     return new Vector(this.x / length, this.y / length)
   }
 

--- a/packages/vecti/test/vecti.test.ts
+++ b/packages/vecti/test/vecti.test.ts
@@ -74,6 +74,12 @@ describe('Vector', () => {
       expect(normalized.length()).toEqual(1)
     })
 
+    test('normalize the zero vector to the zero vector', ({ expect }) => {
+      const normalized = new Vector(0, 0).normalize()
+      expect(normalized.x).toEqual(0)
+      expect(normalized.y).toEqual(0)
+    })
+
     describe('rotate vectors', () => {
       test('by radians', ({ expect }) => {
         const vector = new Vector(1, 0).rotateByRadians(Math.PI * 0.5)

--- a/packages/vecti/test/vecti.test.ts
+++ b/packages/vecti/test/vecti.test.ts
@@ -78,6 +78,7 @@ describe('Vector', () => {
       const normalized = new Vector(0, 0).normalize()
       expect(normalized.x).toEqual(0)
       expect(normalized.y).toEqual(0)
+      expect(normalized.length()).toEqual(0)
     })
 
     describe('rotate vectors', () => {


### PR DESCRIPTION
Return `Vector(0, 0)` when normalizing a zero-length vector, instead of `Vector(NaN, NaN)`.

### Motivation

`new Vector(0, 0).normalize()` currently divides by `length === 0` and returns `Vector(NaN, NaN)`. The NaN then propagates silently through downstream math. The case surfaces in geometry code that computes direction vectors between points that may coincide. Examples: a zero-length polygon edge, or two points that become equal after floating-point rounding.

### Checklist

- Added test: `normalize` on the zero vector returns `Vector(0, 0)` and `length() === 0` (no NaN).
- Existing `normalize vectors` test still passes.
- Added changeset (patch, `fix nan on zero-length normalize`).