### PR TITLE
feat(vecti): add distance method

### DIFF
--- a/.changeset/add-distance-method.md
+++ b/.changeset/add-distance-method.md
@@ -1,0 +1,5 @@
+---
+'vecti': minor
+---
+
+add distance method

--- a/docs/vecti-docs/guide/index.md
+++ b/docs/vecti-docs/guide/index.md
@@ -142,6 +142,21 @@ const b = new Vector(-3, 4)
 console.log(b.length()) // == 5
 ```
 
+### Distance
+
+The distance between two vectors can be calculated using the `distance` method.
+
+::: tip
+Distance is defined as the **L2 norm** of the difference between the two vectors.
+:::
+
+```ts
+const a = new Vector(0, 0)
+const b = new Vector(3, 4)
+
+console.log(a.distance(b)) // == 5
+```
+
 ### Normalization
 
 A normalized version of a vector can be calculated using the `normalize` method.

--- a/packages/vecti/README.md
+++ b/packages/vecti/README.md
@@ -33,7 +33,7 @@
 
 - 🧮 Addition, subtraction, multiplication and division
 - ✨ Dot, cross and Hadamard product
-- 📏 Length and normalization
+- 📏 Length, distance, and normalization
 - 📐 Rotation by radians and degrees
 - 🪨 Immutable data structure encourages chaining
 - 💾 Tiny and typed
@@ -157,6 +157,19 @@ a.length() // == 1
 const b = new Vector(-3, 4)
 
 b.length() // == 5
+```
+
+### Distance
+
+The distance between two vectors can be calculated using the `distance` method.
+
+Distance is defined as the **L2 norm** of the difference between the two vectors.
+
+```ts
+const a = new Vector(0, 0)
+const b = new Vector(3, 4)
+
+a.distance(b) // == 5
 ```
 
 ### Normalization

--- a/packages/vecti/src/index.ts
+++ b/packages/vecti/src/index.ts
@@ -98,6 +98,15 @@ export class Vector {
   }
 
   /**
+   * Calculate the distance between the vector and another vector using the L2 norm.
+   * @param other - The other vector.
+   * @returns The distance between the two vectors.
+   */
+  public distance(other: Vector): number {
+    return this.subtract(other).length()
+  }
+
+  /**
    * Normalize the vector using the L2 norm.
    * @returns The normalized vector.
    */

--- a/packages/vecti/test/vecti.test.ts
+++ b/packages/vecti/test/vecti.test.ts
@@ -67,6 +67,22 @@ describe('Vector', () => {
       expect(length).toEqual(5)
     })
 
+    test('calculate distance between two vectors', ({ expect }) => {
+      const distance = new Vector(0, 0).distance(new Vector(3, 4))
+      expect(distance).toEqual(5)
+    })
+
+    test('calculate distance from a vector to itself as zero', ({ expect }) => {
+      const distance = new Vector(42, 7).distance(new Vector(42, 7))
+      expect(distance).toEqual(0)
+    })
+
+    test('calculate distance symmetrically', ({ expect }) => {
+      const a = new Vector(1, 2)
+      const b = new Vector(-3, 4)
+      expect(a.distance(b)).toEqual(b.distance(a))
+    })
+
     test('normalize vectors', ({ expect }) => {
       const normalized = new Vector(-5, 0).normalize()
       expect(normalized.x).toEqual(-1)
@@ -109,6 +125,7 @@ describe('Vector', () => {
       vector.dot(other)
       vector.cross(other)
       vector.hadamard(other)
+      vector.distance(other)
       vector.rotateByRadians(Math.PI * 0.5)
       vector.rotateByDegrees(180)
       expect(vector).toEqual(new Vector(1, 1))

--- a/packages/vecti/test/vecti.test.ts
+++ b/packages/vecti/test/vecti.test.ts
@@ -72,6 +72,11 @@ describe('Vector', () => {
       expect(distance).toEqual(5)
     })
 
+    test('calculate distance as an absolute value', ({ expect }) => {
+      const distance = new Vector(-3, -4).distance(new Vector(0, 0))
+      expect(distance).toEqual(5)
+    })
+
     test('calculate distance from a vector to itself as zero', ({ expect }) => {
       const distance = new Vector(42, 7).distance(new Vector(42, 7))
       expect(distance).toEqual(0)


### PR DESCRIPTION
Add `Vector#distance(other): number` returning the L2 distance between two vectors.

### Motivation

vecti exposes `length()` for the magnitude of a vector but no first-class distance between two points. Callers currently compose it as `a.subtract(b).length()`. Peer 2D vector libraries provide `distance` directly. Examples: `gl-matrix` `vec2.distance`, paper.js `Point#getDistance`, bezier-js internals.

### Checklist

- Placed next to `length()` to group magnitude-related ops.
- Tests: 3-4-5 Pythagorean case, absolute-value case for negative components, distance-to-self equals zero, symmetry, and added `distance` to the `do not mutate` call list.
- Added changeset (minor, `add distance method`).